### PR TITLE
Added IMDb dataset download instructions (#3)

### DIFF
--- a/data/raw/README.md
+++ b/data/raw/README.md
@@ -1,0 +1,17 @@
+### 🧠 Dataset
+
+**Source:** [IMDb Non-Commercial Datasets](https://datasets.imdbws.com/)
+
+We are using the following files from the official IMDb dataset:
+
+* `title.akas.tsv.gz`
+* `title.basics.tsv.gz`
+* `title.crew.tsv.gz`
+* `title.episode.tsv.gz`
+* `title.principals.tsv.gz`
+* `title.ratings.tsv.gz`
+* `name.basics.tsv.gz`
+
+> ⚠️ **Note:** Due to large file sizes, the raw `.tsv.gz` files are **not included** in this repository.
+> You can manually download them from IMDb.
+


### PR DESCRIPTION
⚠️ Note: Due to large file sizes, the raw .tsv.gz files are not included in this repository.
You can manually download them from IMDb 
Source: [IMDb Non-Commercial Datasets](https://datasets.imdbws.com/)